### PR TITLE
Cannot read property 'tag' of undefined [AngularEditorService.createCustomClass]

### DIFF
--- a/src/lib/angular-editor.service.ts
+++ b/src/lib/angular-editor.service.ts
@@ -172,8 +172,12 @@ export class AngularEditorService {
   }
 
   createCustomClass(customClass: CustomClass) {
-    const tagName = customClass.tag ? customClass.tag : 'span';
-    const newTag = '<' + tagName + ' class="' + customClass.class + '">' + this.selectedText + '</' + tagName + '>';
+    const newTag = this.selectedText;
+    if(customClass){
+      const tagName = customClass.tag ? customClass.tag : 'span';
+      newTag = '<' + tagName + ' class="' + customClass.class + '">' + this.selectedText + '</' + tagName + '>';
+    }
+    
     this.insertHtml(newTag);
   }
 }

--- a/src/lib/angular-editor.service.ts
+++ b/src/lib/angular-editor.service.ts
@@ -172,7 +172,7 @@ export class AngularEditorService {
   }
 
   createCustomClass(customClass: CustomClass) {
-    const newTag = this.selectedText;
+    let newTag = this.selectedText;
     if(customClass){
       const tagName = customClass.tag ? customClass.tag : 'span';
       newTag = '<' + tagName + ' class="' + customClass.class + '">' + this.selectedText + '</' + tagName + '>';


### PR DESCRIPTION
Hi @kolkov, I've detected a bug on **AngularEditorService.createCustomClass** method.  
If the **customClass** param is **undefined** then the error is fired: **Cannot read property 'tag' of undefined**.
Basically when the "Clear Class" option is selected you try to get the array object **this.customClasses[-1]** that in this case is undefined.

Here is the propose file with fixes.