### PR TITLE
Removed unique id

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.component.html
+++ b/projects/angular-editor/src/lib/angular-editor.component.html
@@ -1,9 +1,9 @@
-<div (focus)="onEditorFocus()" class="angular-editor" id="angularEditor" [style.width]="config.width"
+<div (focus)="onEditorFocus()" class="angular-editor" #angularEditor [style.width]="config.width"
      [style.minWidth]="config.minWidth">
   <angular-editor-toolbar *ngIf="config.toolbarPosition === 'top' " #editorToolbar (execute)="executeCommand($event)"></angular-editor-toolbar>
 
   <div class="angular-editor-wrapper" #editorWrapper>
-    <div #editor id="editor" class="angular-editor-textarea" [attr.contenteditable]="config.editable"
+    <div #editor class="angular-editor-textarea" [attr.contenteditable]="config.editable"
          [attr.translate]="config.translate"
          [attr.spellcheck]="config.spellcheck" [style.height]="config.height" [style.minHeight]="config.minHeight" [style.maxHeight]="config.maxHeight"
          (input)="onContentChange($event.target.innerHTML)"


### PR DESCRIPTION
Removed id on HTML elements, for use multiple editors on the same page without break the HTML id uniqueness.