### PR TITLE
fixed empty <br> when deleting all words

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -205,7 +205,7 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
    * @param fn a function
    */
   registerOnChange(fn: any): void {
-    this.onChange = fn;
+    this.onChange = e => (e === '<br>' ? fn('') : fn(e)) ;
   }
 
   /**


### PR DESCRIPTION
fixed empty <br> when deleting all words, in some cases.
Example: when deleting a bold word if the word is the only in the textarea.