### PR TITLE
Fix youtube video HTML missing closing tag

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.service.ts
+++ b/projects/angular-editor/src/lib/angular-editor.service.ts
@@ -202,7 +202,7 @@ export class AngularEditorService {
     const thumbnail = `
       <div style='position: relative'>
         <img style='position: absolute; left:200px; top:140px'
-             src="https://img.icons8.com/color/96/000000/youtube-play.png"
+             src="https://img.icons8.com/color/96/000000/youtube-play.png"/>
         <a href='${videoUrl}' target='_blank'>
           <img src="${imageUrl}" alt="click to watch"/>
         </a>


### PR DESCRIPTION
Fixes a part of #142 where the HTML is broken after inserting a youtube video