### PR TITLE
Fix #172: wrong value returned by code editor when in raw html mode

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.component.html
+++ b/projects/angular-editor/src/lib/angular-editor.component.html
@@ -21,7 +21,7 @@
          [style.minHeight]="config.minHeight"
          [style.maxHeight]="config.maxHeight"
          [style.outline]="config.outline === false ? 'none': undefined"
-         (input)="onContentChange($event.target.innerHTML)"
+         (input)="onContentChange($event.target)"
          (focus)="onTextAreaFocus($event)"
          (blur)="onTextAreaBlur($event)"
          (click)="exec()"

--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -114,10 +114,10 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
     } else if (command !== '') {
       if (command === 'clear') {
         this.editorService.removeSelectedElements(this.getCustomTags());
-        this.onContentChange(this.textArea.nativeElement.innerHTML);
+        this.onContentChange(this.textArea.nativeElement);
       } else if (command === 'default') {
         this.editorService.removeSelectedElements('h1,h2,h3,h4,h5,h6,p,pre');
-        this.onContentChange(this.textArea.nativeElement.innerHTML);
+        this.onContentChange(this.textArea.nativeElement);
       } else {
         this.editorService.executeCommand(command);
       }
@@ -187,9 +187,15 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
 
   /**
    * Executed from the contenteditable section while the input property changes
-   * @param html html string from contenteditable
+   * @param element html element from contenteditable
    */
-  onContentChange(html: string): void {
+  onContentChange(element: HTMLElement): void {
+    let html = '';
+    if (this.modeVisual) {
+      html = element.innerHTML;
+    } else {
+      html = element.innerText;
+    }
     if ((!html || html === '<br>')) {
       html = '';
     }
@@ -331,7 +337,7 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
       this.r.setProperty(editableElement, 'contentEditable', true);
       this.modeVisual = true;
       this.viewMode.emit(true);
-      this.onContentChange(editableElement.innerHTML);
+      this.onContentChange(editableElement);
       editableElement.focus();
     }
     this.editorToolbar.setEditorMode(!this.modeVisual);


### PR DESCRIPTION
This fixes the problem described in the issue by getting raw text from code html node instead of rendered html.