### PR TITLE
Fix #199 - Allow to perform the image upload call with cookie credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ editorConfig: AngularEditorConfig = {
       },
     ],
     uploadUrl: 'v1/image',
+    uploadWithCredentials: false,
     sanitize: true,
     toolbarPosition: 'top',
     toolbarHiddenButtons: [
@@ -173,6 +174,7 @@ For `ngModel` to work, you must import `FormsModule` from `@angular/forms`, or f
 | defaultFontName  | `string` | `-` | no | Set default font such as `Comic Sans MS` |
 | defaultFontSize  | `string` | `-` | no | Set default font size such as `1` - `7` |
 | uploadUrl  | `string` | `-` | no | Set image upload endpoint `https://api.exapple.com/v1/image/upload` |
+| uploadWithCredentials | `bolean` | `false` | no | Set passing or not credentials in the image upload call |
 | fonts  | `Font[]` | `-` | no | Set array of available fonts  `[{name, class},...]` |
 | customClasses  | `CustomClass[]` | `-` | no | Set array of available fonts  `[{name, class, tag},...]` |
 | outline  | `bolean` | `true` | no | Set outline of the editor if in focus |

--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -368,6 +368,7 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
 
   private configure() {
     this.editorService.uploadUrl = this.config.uploadUrl;
+    this.editorService.uploadWithCredentials = this.config.uploadWithCredentials;
     if (this.config.defaultParagraphSeparator) {
       this.editorService.setDefaultParagraphSeparator(this.config.defaultParagraphSeparator);
     }

--- a/projects/angular-editor/src/lib/angular-editor.service.ts
+++ b/projects/angular-editor/src/lib/angular-editor.service.ts
@@ -16,6 +16,7 @@ export class AngularEditorService {
   savedSelection: Range | null;
   selectedText: string;
   uploadUrl: string;
+  uploadWithCredentials: boolean;
 
   constructor(
     private http: HttpClient,
@@ -163,6 +164,7 @@ export class AngularEditorService {
     return this.http.post<UploadResponse>(this.uploadUrl, uploadData, {
       reportProgress: true,
       observe: 'events',
+      withCredentials: this.uploadWithCredentials,
     });
   }
 

--- a/projects/angular-editor/src/lib/config.ts
+++ b/projects/angular-editor/src/lib/config.ts
@@ -25,6 +25,7 @@ export interface AngularEditorConfig {
   defaultFontName?: string;
   defaultFontSize?: '1' | '2' | '3' | '4' | '5' | '6' | '7' | string;
   uploadUrl?: string;
+  uploadWithCredentials?: boolean;
   fonts?: Font[];
   customClasses?: CustomClass[];
   sanitize?: boolean;
@@ -55,6 +56,7 @@ export const angularEditorConfig: AngularEditorConfig = {
     {class: 'comic-sans-ms', name: 'Comic Sans MS'}
   ],
   uploadUrl: 'v1/image',
+  uploadWithCredentials: false,
   sanitize: true,
   toolbarPosition: 'top',
   outline: true,


### PR DESCRIPTION
Fix #199 
Added a new config option (false by default) to add "withCredentials" to the HTTP POST options.