### PR TITLE
FIX #222: IE support in angular editor

### DIFF
--- a/projects/angular-editor-app/src/index.html
+++ b/projects/angular-editor-app/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>

--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
@@ -112,7 +112,7 @@ export class AngularEditorToolbarComponent {
   select = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'P', 'PRE', 'DIV'];
 
   buttons = ['bold', 'italic', 'underline', 'strikeThrough', 'subscript', 'superscript', 'justifyLeft', 'justifyCenter',
-    'justifyRight', 'justifyFull', 'indent', 'outdent', 'insertUnorderedList', 'insertOrderedList', 'link'];
+    'justifyRight', 'justifyFull', 'indent', 'outdent', 'insertUnorderedList', 'insertOrderedList'];
 
   @Input() id: string;
   @Input() uploadUrl: string;

--- a/projects/angular-editor/src/lib/angular-editor.component.html
+++ b/projects/angular-editor/src/lib/angular-editor.component.html
@@ -21,11 +21,10 @@
          [style.minHeight]="config.minHeight"
          [style.maxHeight]="config.maxHeight"
          [style.outline]="config.outline === false ? 'none': undefined"
-         (input)="onContentChange($event.target)"
          (focus)="onTextAreaFocus($event)"
          (blur)="onTextAreaBlur($event)"
          (click)="exec()"
-         (keyup)="exec()"
+         (keyup)="exec();onContentChange($event.target)"
          (mouseout)="onTextAreaMouseOut($event)"
     >
     </div>

--- a/projects/angular-editor/src/lib/angular-editor.service.ts
+++ b/projects/angular-editor/src/lib/angular-editor.service.ts
@@ -29,7 +29,7 @@ export class AngularEditorService {
    */
   executeCommand(command: string) {
     const commands = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'pre'];
-    if (commands.includes(command)) {
+    if (commands.indexOf(command) > -1) {
       this.doc.execCommand('formatBlock', false, command);
       return;
     }
@@ -41,7 +41,7 @@ export class AngularEditorService {
    * @param url string from UI prompt
    */
   createLink(url: string) {
-    if (!url.includes('http')) {
+    if (!(url.indexOf('http') > -1)) {
       this.doc.execCommand('createlink', false, url);
     } else {
       const newUrl = '<a href="' + url + '" target="_blank">' + this.selectedText + '</a>';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Hello Andrey, i fix the ie problems in angular IE:

**Changes**:
- Replace `includes()` with `indexOf()` because `includes()` is not supported in IE.
- Delete the `link` command, i found that document.queryCommandState('link') create an error `ERROR CONTENT [OBJECT OBJECT]` in **IE**.
- Move the `OnChangeContent` from `input` event to `keyup` event.

**Note**:
the `onInput()` & `includes()` events are not supported in IE.

### Expected Behavior: 

![IE support done](https://user-images.githubusercontent.com/4634256/79569555-169dce80-80b8-11ea-863a-12c1449db46e.gif)
 