### PR TITLE
Fix issue with native element undefined on file upload

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
@@ -318,7 +318,7 @@ export class AngularEditorToolbarComponent {
             this.editorService.uploadImage(file).subscribe(e => {
               if (e instanceof HttpResponse) {
                 this.editorService.insertImage(e.body.imageUrl);
-                this.fileReset();
+                event.srcElement.value = null;
               }
             });
         } else {
@@ -330,13 +330,6 @@ export class AngularEditorToolbarComponent {
           reader.readAsDataURL(file);
         }
       }
-  }
-
-  /**
-   * Reset Input
-   */
-  fileReset() {
-    this.myInputFile.nativeElement.value = '';
   }
 
   /**


### PR DESCRIPTION
Fixes issues like #178

When uploading a file to a custom endpoint, the fileReset function throws the error "Cannot read property 'nativeElement' of undefined".

The fileReset can be easily done by settings the srcElement to null instead of using the nativeElement wrapper. The event already has all required properties.