### PR TITLE
Feature/custom buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ editorConfig: AngularEditorConfig = {
 ```
 For `ngModel` to work, you must import `FormsModule` from `@angular/forms`, or for `formControlName`, you must import `ReactiveFormsModule` from `@angular/forms`
 
+### Custom buttons
+
+You can define your custom buttons with custom actions using executeCommandFn. It accepts commands from [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand).
+The first argument of this method is aCommandName and the second argument is aValueArgument. Example shows a button that adds Angular editor logo into the editor.
+```html
+<angular-editor id="editor1" formControlName="htmlContent1" [config]="editorConfig">
+  <ng-template #customButtons let-executeCommandFn="executeCommandFn">
+    <ae-toolbar-set>
+      <ae-button iconClass="fa fa-html5" title="Angular editor logo"
+                 (buttonClick)="executeCommandFn('insertHtml', angularEditorLogo)">
+      </ae-button>
+    </ae-toolbar-set>
+  </ng-template>
+</angular-editor>
+```
+
 ## API
 ### Inputs
 | Input  | Type | Default | Required | Description |

--- a/projects/angular-editor-app/src/app/app.component.html
+++ b/projects/angular-editor-app/src/app/app.component.html
@@ -6,7 +6,13 @@
   <input id="test_input">
   <br><br>
   <angular-editor id="editor1" [(ngModel)]="htmlContent1" [config]="config1" (ngModelChange)="onChange($event)"
-                  (blur)="onBlur($event)"></angular-editor>
+                  (blur)="onBlur($event)">
+    <ng-template #customButtons let-executeCommandFn="executeCommandFn">
+      <ae-toolbar-set>
+        <ae-button iconClass="fa fa-html5" title="Angular editor logo" (buttonClick)="executeCommandFn('insertHtml', angularEditorLogo)"></ae-button>
+      </ae-toolbar-set>
+    </ng-template>
+  </angular-editor>
   <p class="html">
     HTML Output:  {{ htmlContent1 }}
   </p>

--- a/projects/angular-editor-app/src/app/app.component.ts
+++ b/projects/angular-editor-app/src/app/app.component.ts
@@ -2,6 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {AngularEditorConfig} from 'angular-editor';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 
+const ANGULAR_EDITOR_LOGO_URL = 'https://raw.githubusercontent.com/kolkov/angular-editor/master/docs/angular-editor-logo.png?raw=true'
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -14,6 +16,7 @@ export class AppComponent implements OnInit {
 
   htmlContent1 = '';
   htmlContent2 = '';
+  angularEditorLogo = `<img alt="angular editor logo" src="${ANGULAR_EDITOR_LOGO_URL}">`;
 
   config1: AngularEditorConfig = {
     editable: true,

--- a/projects/angular-editor/src/lib/ae-button/ae-button.component.html
+++ b/projects/angular-editor/src/lib/ae-button/ae-button.component.html
@@ -1,0 +1,3 @@
+<button type="button" [title]="title" class="angular-editor-button" (click)="buttonClick.emit()" tabindex="-1"><i
+    [class]="iconClass"></i></button>
+

--- a/projects/angular-editor/src/lib/ae-button/ae-button.component.scss
+++ b/projects/angular-editor/src/lib/ae-button/ae-button.component.scss
@@ -1,0 +1,13 @@
+@import "../style";
+
+.select-button {
+  display: inline-block;
+  // border: #000066 solid;
+  // padding-right: 10px;
+  // padding: auto;
+  &.disabled {
+    cursor: pointer;
+    background-color: #f1f1f1;
+    transition: 0.2s ease;
+  }
+}

--- a/projects/angular-editor/src/lib/ae-button/ae-button.component.spec.ts
+++ b/projects/angular-editor/src/lib/ae-button/ae-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AeButtonComponent } from './ae-button.component';
+
+describe('AeButtonComponent', () => {
+  let component: AeButtonComponent;
+  let fixture: ComponentFixture<AeButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AeButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AeButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/angular-editor/src/lib/ae-button/ae-button.component.ts
+++ b/projects/angular-editor/src/lib/ae-button/ae-button.component.ts
@@ -1,0 +1,18 @@
+import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+
+
+@Component({
+  selector: 'ae-button',
+  templateUrl: './ae-button.component.html',
+  styleUrls: ['./ae-button.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class AeButtonComponent {
+
+  @Input() iconClass = '';
+  @Input() title = '';
+  @Output() buttonClick = new EventEmitter();
+
+  constructor() { }
+
+}

--- a/projects/angular-editor/src/lib/ae-toolbar-set/ae-toolbar-set.component.html
+++ b/projects/angular-editor/src/lib/ae-toolbar-set/ae-toolbar-set.component.html
@@ -1,0 +1,3 @@
+<div class="angular-editor-toolbar-set">
+  <ng-content></ng-content>
+</div>

--- a/projects/angular-editor/src/lib/ae-toolbar-set/ae-toolbar-set.component.spec.ts
+++ b/projects/angular-editor/src/lib/ae-toolbar-set/ae-toolbar-set.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AeToolbarSetComponent } from './ae-toolbar-set.component';
+
+describe('AeToolbarSetComponent', () => {
+  let component: AeToolbarSetComponent;
+  let fixture: ComponentFixture<AeToolbarSetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AeToolbarSetComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AeToolbarSetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/angular-editor/src/lib/ae-toolbar-set/ae-toolbar-set.component.ts
+++ b/projects/angular-editor/src/lib/ae-toolbar-set/ae-toolbar-set.component.ts
@@ -1,0 +1,13 @@
+import {Component, ViewEncapsulation} from '@angular/core';
+
+@Component({
+  selector: 'ae-toolbar-set',
+  templateUrl: './ae-toolbar-set.component.html',
+  styleUrls: ['./ae-toolbar-set.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class AeToolbarSetComponent {
+
+  constructor() { }
+
+}

--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.html
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.html
@@ -159,4 +159,5 @@
             (click)="triggerCommand('toggleEditorMode')" [hidden]="isButtonHidden('toggleEditorMode')" tabindex="-1"><i
       class='fa fa-code'></i></button>
   </div>
+  <ng-content></ng-content>
 </div>

--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.scss
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.scss
@@ -1,13 +1,1 @@
 @import "style";
-
-.select-button {
-  display: inline-block;
-  // border: #000066 solid;
-  // padding-right: 10px;
-  // padding: auto;
-  &.disabled {
-    cursor: pointer;
-    background-color: #f1f1f1;
-    transition: 0.2s ease;
-  }
-}

--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
@@ -1,4 +1,14 @@
-import {Component, ElementRef, EventEmitter, Inject, Input, Output, Renderer2, ViewChild} from '@angular/core';
+import {
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  Output,
+  Renderer2, TemplateRef,
+  ViewChild
+} from '@angular/core';
 import {AngularEditorService, UploadResponse} from './angular-editor.service';
 import {HttpResponse, HttpEvent} from '@angular/common/http';
 import {DOCUMENT} from '@angular/common';

--- a/projects/angular-editor/src/lib/angular-editor.component.html
+++ b/projects/angular-editor/src/lib/angular-editor.component.html
@@ -17,7 +17,13 @@
           [defaultFontSize]="config.defaultFontSize"
           [hiddenButtons]="config.toolbarHiddenButtons"
           (execute)="executeCommand($event)"
-     ></angular-editor-toolbar>
+     >
+       <ng-container
+         [ngTemplateOutlet]="customButtonsTemplateRef"
+         [ngTemplateOutletContext]="{ executeCommandFn: this.executeCommandFn}"
+       >
+       </ng-container>
+     </angular-editor-toolbar>
 
      <div
           class="angular-editor-wrapper"

--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -2,7 +2,7 @@ import {
   AfterViewInit,
   Attribute,
   ChangeDetectorRef,
-  Component,
+  Component, ContentChild,
   ElementRef,
   EventEmitter,
   forwardRef,
@@ -14,7 +14,7 @@ import {
   OnInit,
   Output,
   Renderer2,
-  SecurityContext,
+  SecurityContext, TemplateRef,
   ViewChild
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
@@ -63,6 +63,8 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
   @ViewChild('editor', {static: true}) textArea: ElementRef;
   @ViewChild('editorWrapper', {static: true}) editorWrapper: ElementRef;
   @ViewChild('editorToolbar') editorToolbar: AngularEditorToolbarComponent;
+  @ContentChild("customButtons") customButtonsTemplateRef?: TemplateRef<any>;
+  executeCommandFn = this.executeCommand.bind(this);
 
   @Output() viewMode = new EventEmitter<boolean>();
 
@@ -116,8 +118,9 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
   /**
    * Executed command from editor header buttons
    * @param command string from triggerCommand
+   * @param value
    */
-  executeCommand(command: string) {
+  executeCommand(command: string, value?: string) {
     this.focus();
     if (command === 'focus') {
       return;
@@ -132,7 +135,7 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
         this.editorService.removeSelectedElements('h1,h2,h3,h4,h5,h6,p,pre');
         this.onContentChange(this.textArea.nativeElement);
       } else {
-        this.editorService.executeCommand(command);
+        this.editorService.executeCommand(command, value);
       }
       this.exec();
     }

--- a/projects/angular-editor/src/lib/angular-editor.module.ts
+++ b/projects/angular-editor/src/lib/angular-editor.module.ts
@@ -4,13 +4,15 @@ import {AngularEditorToolbarComponent} from './angular-editor-toolbar.component'
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import { AeSelectComponent } from './ae-select/ae-select.component';
+import {AeButtonComponent} from "./ae-button/ae-button.component";
+import { AeToolbarSetComponent } from './ae-toolbar-set/ae-toolbar-set.component';
 
 @NgModule({
   imports: [
     CommonModule, FormsModule, ReactiveFormsModule
   ],
-  declarations: [AngularEditorComponent, AngularEditorToolbarComponent, AeSelectComponent],
-  exports: [AngularEditorComponent, AngularEditorToolbarComponent]
+  declarations: [AngularEditorComponent, AngularEditorToolbarComponent, AeSelectComponent, AeButtonComponent, AeToolbarSetComponent],
+  exports: [AngularEditorComponent, AngularEditorToolbarComponent, AeButtonComponent, AeToolbarSetComponent]
 })
 export class AngularEditorModule {
 }

--- a/projects/angular-editor/src/lib/angular-editor.service.ts
+++ b/projects/angular-editor/src/lib/angular-editor.service.ts
@@ -24,14 +24,15 @@ export class AngularEditorService {
   /**
    * Executed command from editor header buttons exclude toggleEditorMode
    * @param command string from triggerCommand
+   * @param value
    */
-  executeCommand(command: string) {
+  executeCommand(command: string, value?: string) {
     const commands = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'pre'];
     if (commands.includes(command)) {
       this.doc.execCommand('formatBlock', false, command);
       return;
     }
-    this.doc.execCommand(command, false, null);
+    this.doc.execCommand(command, false, value);
   }
 
   /**

--- a/projects/angular-editor/src/public-api.ts
+++ b/projects/angular-editor/src/public-api.ts
@@ -4,6 +4,9 @@
 
 export * from './lib/angular-editor.service';
 export * from './lib/angular-editor.component';
+export * from './lib/ae-button/ae-button.component';
+export * from './lib/ae-toolbar-set/ae-toolbar-set.component';
+export * from './lib/ae-select/ae-select.component';
 export * from './lib/angular-editor-toolbar.component';
 export * from './lib/angular-editor.module';
 export { AngularEditorConfig, CustomClass } from './lib/config';


### PR DESCRIPTION
I created PR for support for custom buttons in the toolbar. In our company, we needed this functionality and thus we needed to choose to pick fate-editor instead of this. But Fate is not under maintenance.

Usage is simple: You can define your custom buttons with custom actions using executeCommandFn. It accepts commands from [execCommand](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand).
The first argument of this method is aCommandName and the second argument is aValueArgument. Example shows a button that adds Angular editor logo into the editor.
```html
<angular-editor id="editor1" formControlName="htmlContent1" [config]="editorConfig">
  <ng-template #customButtons let-executeCommandFn="executeCommandFn">
    <ae-toolbar-set>
      <ae-button iconClass="fa fa-html5" title="Angular editor logo"
                 (buttonClick)="executeCommandFn('insertHtml', angularEditorLogo)">
      </ae-button>
    </ae-toolbar-set>
  </ng-template>
</angular-editor>