### PR TITLE
Issue 436. Selecting font issue when inside modal

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.html
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.html
@@ -76,7 +76,7 @@
   </div>
   <div class="angular-editor-toolbar-set">
 
-    <ae-select class="select-font" [options]="fonts"
+    <ae-select class="select-font" [options]="fontsList"
                [(ngModel)]="fontName"
                (change)="setFontName(fontName)"
                [disabled]="htmlMode"

--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
@@ -2,7 +2,7 @@ import {Component, ElementRef, EventEmitter, Inject, Input, Output, Renderer2, V
 import {AngularEditorService, UploadResponse} from './angular-editor.service';
 import {HttpResponse, HttpEvent} from '@angular/common/http';
 import {DOCUMENT} from '@angular/common';
-import {CustomClass} from './config';
+import { CustomClass, Font} from './config';
 import {SelectOption} from './ae-select/ae-select.component';
 import { Observable } from 'rxjs';
 
@@ -119,7 +119,16 @@ export class AngularEditorToolbarComponent {
   @Input() uploadUrl: string;
   @Input() upload: (file: File) => Observable<HttpEvent<UploadResponse>>;
   @Input() showToolbar: boolean;
-  @Input() fonts: SelectOption[] = [{label: '', value: ''}];
+
+  _fonts: Font[];
+  fontsList: SelectOption[] = [{ label: '', value: '' }];
+  @Input()
+  set fonts(fonts: Font[]) { 
+    if (fonts) {
+      this._fonts = fonts;
+      this.fontsList = this._fonts.map((x, i) => ({ label: x.name, value: x.name }));
+    }
+  }
 
   @Input()
   set customClasses(classes: CustomClass[]) {

--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -395,9 +395,7 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
 
   getFonts() {
     const fonts = this.config.fonts ? this.config.fonts : angularEditorConfig.fonts;
-    return fonts.map(x => {
-      return {label: x.name, value: x.name};
-    });
+    return fonts;
   }
 
   getCustomTags() {


### PR DESCRIPTION
[https://github.com/kolkov/angular-editor/issues/436](https://github.com/kolkov/angular-editor/issues/436)

Seems to be an issue with the font select when inside an angular material dialog/modal (have seen others report it with other toolkits)

I noticed that the only drop down affected by the issue is the font select.
Changed the font select code to roughly match the custom class drop down select. 


