### PR TITLE
Allow to alter styleWithCSS flag

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -96,6 +96,9 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
 
   ngOnInit() {
     this.config.toolbarPosition = this.config.toolbarPosition ? this.config.toolbarPosition : angularEditorConfig.toolbarPosition;
+    if (this.config.styleWithCSS) {
+        this.doc.execCommand('styleWithCSS', null, true);
+    }
   }
 
   ngAfterViewInit() {
@@ -108,7 +111,7 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
     if (this.config.rawPaste) {
       event.preventDefault();
       const text = event.clipboardData.getData('text/plain');
-      document.execCommand('insertHTML', false, text);
+      this.doc.execCommand('insertHTML', false, text);
       return text;
     }
   }

--- a/projects/angular-editor/src/lib/config.ts
+++ b/projects/angular-editor/src/lib/config.ts
@@ -35,6 +35,7 @@ export interface AngularEditorConfig {
   customClasses?: CustomClass[];
   sanitize?: boolean;
   toolbarPosition?: 'top' | 'bottom';
+  styleWithCSS?: boolean;
   outline?: boolean;
   toolbarHiddenButtons?: string[][];
   rawPaste?: boolean;
@@ -65,6 +66,7 @@ export const angularEditorConfig: AngularEditorConfig = {
   uploadWithCredentials: false,
   sanitize: true,
   toolbarPosition: 'top',
+  styleWithCSS: false,
   outline: true,
   /*toolbarHiddenButtons: [
     ['bold', 'italic', 'underline', 'strikeThrough', 'superscript', 'subscript'],


### PR DESCRIPTION
We cannot use font tags when we use any PDF Generator, so the only solution is to use this native function to style everything with styles instead of tags.