### PR TITLE
Use fonts from node_modules instead of CDN

### DIFF
--- a/projects/angular-editor/src/lib/style.scss
+++ b/projects/angular-editor/src/lib/style.scss
@@ -1,4 +1,4 @@
-$fa-font-path: "https://netdna.bootstrapcdn.com/font-awesome/4.7.0/fonts" !default; // for referencing Bootstrap CDN font files directly
+$fa-font-path: "~font-awesome/fonts" !default;
 @import "~font-awesome/scss/font-awesome.scss";
 
 a {


### PR DESCRIPTION
I want to use this library inside a offline environment, but right now the library fetches the font-awesome font by using a CDN. This change will make sure it uses the font from the node_modules when building the library.