### PR TITLE
Remove console.log from focus

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor-toolbar.component.ts
@@ -380,6 +380,5 @@ export class AngularEditorToolbarComponent {
 
   focus() {
     this.execute.emit('focus');
-    console.log('focused');
   }
 }


### PR DESCRIPTION
"focus" get's logged every time you enter color select. It might be better to remove it