### PR TITLE
bugfix added sanitization html preview to text.

### DIFF
--- a/projects/angular-editor/src/lib/editor/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/editor/angular-editor.component.ts
@@ -354,14 +354,19 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
     } else {
       if (this.doc.querySelectorAll) {
         // if sanitize: true the html element, from preview to text, is sanitized according the sanitizer config. 
-        if(this.config.sanitize || this.config.sanitize === undefined){
+        if(this.config.sanitize !== false){
           editableElement.innerText = this.sanitizer.sanitize(SecurityContext.HTML, editableElement.innerText)
         }
         this.r.setProperty(editableElement, 'innerHTML', editableElement.innerText);
       } else {
         oContent = this.doc.createRange();
         oContent.selectNodeContents(editableElement.firstChild);
-        this.r.setProperty(editableElement, 'innerHTML', oContent.toString());
+        let oContentString = oContent.toString()
+        // if sanitize: true the oContent is sanitized according the sanitizer config. 
+        if(this.config.sanitize !== false){
+          oContentString = this.sanitizer.sanitize(SecurityContext.HTML, oContentString)
+        }
+        this.r.setProperty(editableElement, 'innerHTML', oContentString);
       }
       this.r.setProperty(editableElement, 'contentEditable', true);
       this.modeVisual = true;


### PR DESCRIPTION
Hi @kolkov and contributors,

I've opened this PR to fix #580, the issue was in **toggleEditorMode** method.
According to the existing logic I made the sanitization optional only if the sanitizer is enabled. 
I made also some tests and the xss is not triggered anymore. Anyway it may happen for some tags that are target of the sanitizer, returned as empty so the user will not have back the same html but I guess it's ok (it's how the sanitizer implemented into the project work).

Finally I would like to ask you if a **CVE** can be requested for the xss.

Thanks!