### PR TITLE
fix(custom-class): preserve HTML structure in multiline selections (#594)

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.service.spec.ts
+++ b/projects/angular-editor/src/lib/angular-editor.service.spec.ts
@@ -2,16 +2,146 @@ import {inject, TestBed} from '@angular/core/testing';
 
 import {AngularEditorService} from './angular-editor.service';
 import {HttpClientModule} from '@angular/common/http';
+import {CustomClass} from './config';
 
 describe('AngularEditorService', () => {
+  let service: AngularEditorService;
+  let testContainer: HTMLDivElement;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpClientModule ],
       providers: [AngularEditorService]
     });
+    service = TestBed.inject(AngularEditorService);
+
+    // Create a test container for DOM manipulation tests
+    testContainer = document.createElement('div');
+    testContainer.id = 'test-editor';
+    testContainer.contentEditable = 'true';
+    document.body.appendChild(testContainer);
   });
 
-  it('should be created', inject([AngularEditorService], (service: AngularEditorService) => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    // Clean up test container
+    if (testContainer && testContainer.parentNode) {
+      testContainer.parentNode.removeChild(testContainer);
+    }
+  });
+
+  it('should be created', inject([AngularEditorService], (svc: AngularEditorService) => {
+    expect(svc).toBeTruthy();
   }));
+
+  describe('createCustomClass', () => {
+    it('should not apply class when no selection', () => {
+      const customClass: CustomClass = { name: 'Test', class: 'test-class' };
+      service.savedSelection = null;
+
+      // Should not throw
+      expect(() => service.createCustomClass(customClass)).not.toThrow();
+    });
+
+    it('should not apply class when customClass is null', () => {
+      const range = document.createRange();
+      service.savedSelection = range;
+
+      expect(() => service.createCustomClass(null as any)).not.toThrow();
+    });
+
+    it('should apply inline class to single text selection', () => {
+      // Setup: single text node
+      testContainer.innerHTML = '<p>Hello World</p>';
+      const textNode = testContainer.querySelector('p')!.firstChild!;
+
+      // Create selection range for "World"
+      const range = document.createRange();
+      range.setStart(textNode, 6);
+      range.setEnd(textNode, 11);
+
+      // Set selection
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+
+      service.savedSelection = range;
+      service.selectedText = 'World';
+
+      const customClass: CustomClass = { name: 'Test', class: 'highlight', mode: 'inline' };
+      service.createCustomClass(customClass);
+
+      // Verify span was created with class
+      const span = testContainer.querySelector('span.highlight');
+      expect(span).toBeTruthy();
+      expect(span!.textContent).toBe('World');
+    });
+
+    it('should apply block class to multiple paragraphs', () => {
+      // Setup: multiple paragraphs
+      testContainer.innerHTML = '<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>';
+      const paragraphs = testContainer.querySelectorAll('p');
+
+      // Create selection range spanning all paragraphs
+      const range = document.createRange();
+      range.setStart(paragraphs[0].firstChild!, 0);
+      range.setEnd(paragraphs[2].firstChild!, paragraphs[2].textContent!.length);
+
+      // Set selection
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+
+      service.savedSelection = range;
+      service.selectedText = 'First paragraph\nSecond paragraph\nThird paragraph';
+
+      const customClass: CustomClass = { name: 'Test', class: 'block-highlight', mode: 'block' };
+      service.createCustomClass(customClass);
+
+      // Verify class was applied to paragraphs
+      const highlightedParagraphs = testContainer.querySelectorAll('p.block-highlight');
+      expect(highlightedParagraphs.length).toBeGreaterThan(0);
+    });
+
+    it('should use auto mode by default', () => {
+      testContainer.innerHTML = '<p>Single paragraph</p>';
+      const p = testContainer.querySelector('p')!;
+      const textNode = p.firstChild!;
+
+      const range = document.createRange();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, textNode.textContent!.length);
+
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+
+      service.savedSelection = range;
+      service.selectedText = 'Single paragraph';
+
+      // No mode specified - should default to 'auto'
+      const customClass: CustomClass = { name: 'Test', class: 'auto-class' };
+      service.createCustomClass(customClass);
+
+      // For single block, auto mode should use inline wrapping
+      const result = testContainer.querySelector('.auto-class');
+      expect(result).toBeTruthy();
+    });
+
+    it('should toggle class when applied twice in block mode', () => {
+      testContainer.innerHTML = '<p class="toggle-class">Paragraph with class</p>';
+      const p = testContainer.querySelector('p')!;
+      const textNode = p.firstChild!;
+
+      const range = document.createRange();
+      range.selectNodeContents(p);
+
+      service.savedSelection = range;
+
+      const customClass: CustomClass = { name: 'Test', class: 'toggle-class', mode: 'block' };
+      service.createCustomClass(customClass);
+
+      // Class should be removed (toggled off)
+      expect(p.classList.contains('toggle-class')).toBeFalse();
+    });
+  });
 });

--- a/projects/angular-editor/src/lib/config.ts
+++ b/projects/angular-editor/src/lib/config.ts
@@ -2,10 +2,33 @@ import { UploadResponse } from './angular-editor.service';
 import { HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
+/**
+ * Custom class configuration for applying styles to selected content.
+ *
+ * @example
+ * // Basic usage (inline span)
+ * { name: 'Red Text', class: 'text-red' }
+ *
+ * // Block-level class (applies to each paragraph)
+ * { name: 'Highlight', class: 'highlight', mode: 'block' }
+ *
+ * // Auto mode (smart detection)
+ * { name: 'Quote', class: 'quote', mode: 'auto', tag: 'div' }
+ */
 export interface CustomClass {
+  /** Display name shown in dropdown */
   name: string;
+  /** CSS class to apply */
   class: string;
+  /** HTML tag to use for wrapping (default: 'span') */
   tag?: string;
+  /**
+   * Application mode:
+   * - 'inline': Always wrap selection in a single element (legacy behavior)
+   * - 'block': Apply class to each block element in selection
+   * - 'auto': Smart detection - inline for single block, block for multiple (default)
+   */
+  mode?: 'inline' | 'block' | 'auto';
 }
 
 export interface Font {


### PR DESCRIPTION
## Summary

Fixes #594 - When applying custom class, multiline blocks were converted to single line, losing all HTML structure (paragraphs, fonts, lists, etc.).

### Root Cause
The `createCustomClass()` method used `sel.toString()` which returns **plain text only**, stripping all HTML structure.

### Solution
Implemented an enterprise-level solution with smart block/inline detection:

- **New `mode` option** for `CustomClass` interface:
  - `'inline'` - Wrap selection in single element (legacy behavior)
  - `'block'` - Apply class to each block element in selection
  - `'auto'` (default) - Smart detection based on selection span

- **DOM Range API** with `extractContents()` + `insertNode()` pattern instead of `sel.toString()`

- **TreeWalker-based block detection** for finding P, DIV, H1-H6, LI, etc.

- **Toggle behavior** in block mode - removes class if already present

### Example Usage

```typescript
customClasses: [
  { name: 'Red Text', class: 'redText' },  // Uses 'auto' by default
  { name: 'Block Highlight', class: 'highlight', mode: 'block' },
  { name: 'Inline Style', class: 'inline', mode: 'inline' }
]
```

## Changes

- `config.ts` - Extended `CustomClass` interface with `mode` option
- `angular-editor.service.ts` - New implementation of `createCustomClass()` with helper methods
- `angular-editor.service.spec.ts` - Added 6 comprehensive unit tests

## Test Plan

- [x] TypeScript compilation passes
- [x] Library builds successfully (ng-packagr)
- [x] All 19 unit tests pass (13 existing + 6 new)
- [ ] Manual testing in demo app

## Before/After

**Before (broken):**
```html
<!-- Input -->
<p>First</p><p>Second</p><p>Third</p>

<!-- After applying class - WRONG -->
<span class="redText">First&#10;Second&#10;Third</span>
```

**After (fixed):**
```html
<!-- Input -->
<p>First</p><p>Second</p><p>Third</p>

<!-- After applying class with mode: 'block' - CORRECT -->
<p class="redText">First</p><p class="redText">Second</p><p class="redText">Third</p>
```